### PR TITLE
Playbooks for the blog post about enforcing compliance

### DIFF
--- a/enforcing-compliance/cleanup.yaml
+++ b/enforcing-compliance/cleanup.yaml
@@ -1,0 +1,32 @@
+---
+# This playbook deletes the resources created by `setup.yaml` and
+# `tweaked-setup.yaml`.
+#
+# See https://steampunk.si/blog/aws-collection-idempotency-check-mode-diff/ for details.
+
+- hosts: localhost
+  gather_facts: no
+
+  tasks:
+
+    - name: Retrieve the steamy-server instance
+      steampunk.aws.ec2_instance_info:
+        names: steamy-server
+      register: instances
+
+    - name: Remove the steamy-eni network interface
+      steampunk.aws.ec2_network_interface:
+        id: "{{ instances.objects[0].secondary_network_interfaces[0] }}"
+        state: absent
+
+    - name: Remove the dangerous-secgroup security group
+      steampunk.aws.ec2_security_group:
+        name: dangerous-secgroup
+        vpc: "{{ instances.objects[0].vpc }}"
+        state: absent
+
+    - name: Remove the steamy-server instance
+      steampunk.aws.ec2_instance:
+        id: "{{ instances.objects[0].id }}"
+        state: absent
+        wait_state: false

--- a/enforcing-compliance/setup.yaml
+++ b/enforcing-compliance/setup.yaml
@@ -1,0 +1,52 @@
+---
+# With this playbook, we set up a baseline state that we want to comply with.
+#
+# We set up an EC2 instance and an EC2 Elastic Network Interface.
+# We associate the network interface with the default security group for the
+# VPC we're operating in, and attach it to the instance.
+#
+# See https://steampunk.si/blog/aws-collection-idempotency-check-mode-diff/ for details.
+
+- hosts: localhost
+  gather_facts: no
+
+  vars:
+    # Uncomment the following variables and set them to something that is
+    # accessible using your account.
+    #subnet_id: subnet-06a0f705bc79538ed
+    #ami_id: ami-085925f297f89fce1
+    #key_pair: tst-keypair
+    #type: t3.micro
+
+  tasks:
+
+    - name: Create the steamy-server instance for running a simple app
+      steampunk.aws.ec2_instance:
+        name: steamy-server
+        type: "{{ type }}"
+        subnet: "{{ subnet_id }}"
+        ami: "{{ ami_id }}"
+        key_pair: "{{ key_pair }}"
+        monitoring: detailed
+        tags:
+          app: steamy
+          env: staging
+      register: instance
+
+    - name: Retrieve the default security group for the VPC
+      steampunk.aws.ec2_security_group:
+        name: default
+        vpc: "{{ instance.object.vpc }}"
+      register: default_secgroup
+
+    - name: Create a dedicated network interface and attach it to steamy-server
+      steampunk.aws.ec2_network_interface:
+        name: steamy-eni
+        source_dest_check: true
+        subnet: "{{ instance.object.subnet }}"
+        attachment:
+          instance: "{{ instance.object.id }}"
+          keep_on_termination: false
+        security_groups:
+          - "{{ default_secgroup.object.id }}"
+        clear_security_groups: true

--- a/enforcing-compliance/tweaked-setup.yaml
+++ b/enforcing-compliance/tweaked-setup.yaml
@@ -1,0 +1,46 @@
+---
+# This playbook tweaks the AWS resources created by `setup.yaml`.
+# It is the source of configuration drift from the initial state.
+#
+# See https://steampunk.si/blog/aws-collection-idempotency-check-mode-diff/ for details.
+
+- hosts: localhost
+  gather_facts: no
+
+  tasks:
+
+    - name: Retrieve the steamy-server instance
+      steampunk.aws.ec2_instance_info:
+        names: steamy-server
+      register: instances
+
+    - name: Modify configuration of the steamy-server instance
+      steampunk.aws.ec2_instance:
+        id: "{{ instances.objects[0].id }}"
+        monitoring: basic  # downgrade from detailed
+        on_instance_initiated_shutdown: terminate  # terminate instead of stopping
+        tags:
+          env: dev  # used to be staging, we make it dev
+      register: instance
+
+    - name: Create a security group to permit SMB traffic from anywhere
+      steampunk.aws.ec2_security_group:
+        name: dangerous-secgroup
+        vpc: "{{ instance.object.vpc }}"
+        description: Permissions for SMB protocol to the instance
+        ingress:
+          rules:
+            - protocol: tcp
+              port: 445
+              ip_ranges:
+                - cidr: 0.0.0.0
+      register: dangerous_secgroup
+
+    - name: Extend steamy-eni's security groups, and update source/dest checking
+      steampunk.aws.ec2_network_interface:
+        id: "{{ instance.object.secondary_network_interfaces[0] }}"
+        attachment:
+          instance: "{{ instance.object.id }}"
+        security_groups:
+          - "{{ dangerous_secgroup.object.id }}"
+        source_dest_check: false


### PR DESCRIPTION
We add the playbooks required for running the examples in the upcoming blog post about enforcing compliance.